### PR TITLE
fix(manjarolinux-distcc): updated logic for renovate VERSION

### DIFF
--- a/apps/manjarolinux-distcc/ci/latest.sh
+++ b/apps/manjarolinux-distcc/ci/latest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# renovate: datasource=docker image=docker.io/manjarolinux/base
-version=20250323
+# renovate: datasource=docker depName=docker.io/manjarolinux/base
+VERSION="20250323"
 
-printf "%s" "${version}"
+printf "%s" "${VERSION}"


### PR DESCRIPTION
- Updated Renovate comment to use `depName`