### PR TITLE
feat: update pgvector, pgvecto-rs and vchord versions

### DIFF
--- a/apps/bitnami-postgres-pgvecto-rs-vchord/Dockerfile
+++ b/apps/bitnami-postgres-pgvecto-rs-vchord/Dockerfile
@@ -1,15 +1,20 @@
 ARG PGVECTORS_TAG=pg16-v0.3.0-${TARGETARCH}
+ARG PGVECTOR_TAG=0.8.0-pg16
 ARG VCHORD_TAG=pg16-v0.3.0-${TARGETARCH}
 
 ARG VERSION
 
 FROM tensorchord/pgvecto-rs-binary:${PGVECTORS_TAG} AS pgvecto-rs-binary
-FROM tensorchord/vchord-binary:${PGVECTORS_TAG} AS vchord-binary
+FROM tensorchord/vchord-binary:${VCHORD_TAG} AS vchord-binary
+FROM pgvector/pgvector:${PGVECTOR_TAG} AS pgvector
 
 FROM docker.io/bitnami/postgresql:${VERSION}
 
 COPY --from=pgvecto-rs-binary /pgvecto-rs-binary-release.deb /tmp/pgvecto-rs.deb
 COPY --from=vchord-binary /workspace/postgresql-16-vchord*.deb /tmp/vchord.deb
+
+COPY --from=pgvector /usr/lib/postgresql/*/lib/vector.so /opt/bitnami/postgresql/lib/
+COPY --from=pgvector /usr/share/postgresql/*/extension/vector* /opt/bitnami/postgresql/share/extension/
 
 USER root
 


### PR DESCRIPTION
Updates the versions of `pgvector`, `pgvecto-rs`, and `vchord` to their latest available releases. This includes copying necessary files from the `pgvector` image to the Bitnami PostgreSQL image for extension functionality.

- Updated `PGVECTORS_TAG` and introduced `PGVECTOR_TAG` for version control.
- Copied `vector.so` and extension files from `pgvector` image.